### PR TITLE
Only set umode +R if the nickname is verified

### DIFF
--- a/languages/nickserv.en.lang
+++ b/languages/nickserv.en.lang
@@ -55,6 +55,13 @@ NS_HELP_DROPNICK_LONG
 	This cannot be undone. Releasing a nickname in this way will allow others to
 	make use of it, or register it for their use, so make sure you really want
 	this.
+NS_HELP_VERIFY_SHORT
+	%s: Sets +R if you recently verified your nickname.
+NS_HELP_VERIFY_LONG
+	Usage: VERIFY
+	
+	Checks the database to determine whether or not your nickname is verified.
+	If it is and you are not currently mode +R, sets +R.
 NS_HELP_ACCESS_SHORT
 	%s: Maintains the nickname ACCESS list.
 NS_HELP_ACCESS_LONG
@@ -844,3 +851,7 @@ NS_RESETPASS_FAIL
 	Failed to reset to a random password
 NS_RESETPASS_SUCCESS
 	Successfully reset password for %s to %s
+NS_VERIFY_FAIL
+	To set +R, your nick must be registered and verified.
+NS_VERIFY_SUCCESS
+	Successfully set +R on your nick.

--- a/modules/nickserv.c
+++ b/modules/nickserv.c
@@ -90,6 +90,7 @@ static void m_list(struct Service *, struct Client *, int, char *[]);
 static void m_status(struct Service *, struct Client *, int, char*[]);
 static void m_enslave(struct Service *, struct Client *, int, char*[]);
 static void m_dropnick(struct Service *, struct Client *, int, char*[]);
+static void m_verify(struct Service *, struct Client *, int, char*[]);
 
 static void m_set_language(struct Service *, struct Client *, int, char *[]);
 static void m_set_password(struct Service *, struct Client *, int, char *[]);
@@ -296,6 +297,11 @@ static struct ServiceMessage enslave_msgtab = {
 static struct ServiceMessage dropnick_msgtab = {
   NULL, "DROPNICK", 0, 1, 1, 0, OPER_FLAG, NS_HELP_DROPNICK_SHORT,
     NS_HELP_DROPNICK_LONG, m_dropnick
+};
+
+static struct ServiceMessage verify_msgtab = {
+  NULL, "VERIFY", 0, 0, 1, 0, USER_FLAG, NS_HELP_VERIFY_SHORT,
+  NS_HELP_VERIFY_LONG, m_verify
 };
 
 INIT_MODULE(nickserv, "$Revision$")
@@ -2354,6 +2360,22 @@ m_status(struct Service *service, struct Client *client, int parc, char *parv[])
   {
     reply_user(service, service, client, NS_STATUS_OFFLINE, name);
     return;  
+  }
+}
+
+static void
+m_verify(struct Service *service, struct Client *client, int parc, char *parv[])
+{
+  if(IsIdentified(client) && nickname_get_verified(client->nickname))
+  {
+    send_umode(NULL, client, "+R");
+    reply_user(service, service, client, NS_VERIFY_SUCCESS);
+    return;
+  }
+  else
+  {
+    reply_user(service, service, client, NS_VERIFY_FAIL);
+    return;
   }
 }
 

--- a/modules/oftc.c
+++ b/modules/oftc.c
@@ -621,7 +621,7 @@ oftc_identify(va_list args)
   /* XXX */
   uplink = uplink;
   
-  if(!IsConnecting(me.uplink) || !IsIdentified(client))
+  if((!IsConnecting(me.uplink) || !IsIdentified(client)) && nickname_get_verified(client->nickname))
     send_umode(NULL, client, "+R");
 
   SetIdentified(client);


### PR DESCRIPTION
This change adds an additional check to only set +R if the nickname is
verified. It also adds an additional nickserv command, VERIFY, which
checks if the nickname was verified and sets +R appropriately if so.