### PR TITLE
 updated nickserv set private text 

### DIFF
--- a/languages/nickserv.en.lang
+++ b/languages/nickserv.en.lang
@@ -350,8 +350,8 @@ NS_HELP_SET_PRIVATE_LONG
 	Usage SET PRIVATE [ON|OFF]
 	
 	Enables the private flag on your nickname which prevents your e-mail address
-	being shown in an INFO request, and also prevents your nickname showing in a
-	LIST.
+	being shown in an INFO request, prevents your nickname showing in a LIST, and
+	also prevents the information from showing in the web interface.
 NS_HELP_LINK_SHORT
 	%s: Link this nickname to a master nickname.
 NS_HELP_LINK_LONG

--- a/languages/nickserv.en.lang
+++ b/languages/nickserv.en.lang
@@ -351,7 +351,7 @@ NS_HELP_SET_PRIVATE_LONG
 	
 	Enables the private flag on your nickname which prevents your e-mail address
 	being shown in an INFO request, prevents your nickname showing in a LIST, and
-	also prevents the information from showing in the web interface.
+	also prevents the information from being shown in the web interface.
 NS_HELP_LINK_SHORT
 	%s: Link this nickname to a master nickname.
 NS_HELP_LINK_LONG


### PR DESCRIPTION
pabs suggested that the nickserv `set private` text should be expanded to mention the website.