### PR TITLE
src/channel.c: drop conflicting 'on_channel_created_cb' definition

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -50,8 +50,6 @@ static BlockHeap *topic_heap = NULL;
 BlockHeap *ban_heap            = NULL;
 dlink_list global_channel_list = { NULL, NULL, 0 };
 
-struct Callback *on_channel_created_cb;
-
 void
 init_channel(void)
 {


### PR DESCRIPTION
On gcc-10 services fail to build as:

```
  ld: services-interface.o:src/interface.c:89:
    multiple definition of `on_channel_created_cb';
    services-channel.o:src/channel.c:53: first defined here
```

It is exposed by a gcc-10 change to default to `fno-common`:
  https://gcc.gnu.org/gcc-10/porting_to.html

I dropped `on_channel_created_cb` definition in `src/channel.c`
as it does not seem to be used there.