### PR TITLE
GanneffServ: make it possible to not kill irccloud

### DIFF
--- a/languages/ganneffserv.en.lang
+++ b/languages/ganneffserv.en.lang
@@ -75,3 +75,18 @@ GS_HLP_SRV_LONG
 	IN ROTATION.
 	
 	EVERY user that connects on this server WILL BE KLINED!
+GS_HLP_PRT_SHORT
+	%s: Protect users from akill triggered by another similar user
+GS_HLP_PRT_LONG
+	Takes a hostmask (or a regular expression if it starts with ^).
+
+	When a matching user trips on a trap, only they will be killed
+	instead of causing collateral damage to other matching users.
+
+	Usage: PROTECT <mask|regex> :<reason>
+GS_HLP_UPR_SHORT
+	%s: Delete protection for adjacent users
+GS_HLP_UPR_LONG
+	Delete collateral damage protection for matching users.
+
+	Usage: UNPROTECT <mask|regex>

--- a/modules/GanneffServ.rb
+++ b/modules/GanneffServ.rb
@@ -326,7 +326,7 @@ class GanneffServ < ServiceModule
       debug(LOG_DEBUG, "#{client.name} called BADSERV and the parms are #{parv.join(",")}")
       server = parv[1].downcase
 
-      if server =~ /.*\.oftc.net$/
+      if server =~ /.*\.oftc\.net$/
         debug(LOG_DEBUG, "#{server} seems to be an oftc server, proceeding")
         @badserver = server
         reply(client, "#{server} is now marked as a bad server, all new connections will be killed")

--- a/sql/ganneffserv-pgsql.sql
+++ b/sql/ganneffserv-pgsql.sql
@@ -8,6 +8,7 @@ CREATE TABLE ganneffserv (
   kills   INTEGER NOT NULL DEFAULT 0,
   monitor_only BOOLEAN NOT NULL DEFAULT 'False'
 );
+CREATE UNIQUE INDEX ganneffserv_channel_idx ON ganneffserv (irc_lower(channel));
 
 DROP TABLE IF EXISTS ganneffprotect CASCADE;
 CREATE TABLE ganneffprotect (
@@ -16,6 +17,5 @@ CREATE TABLE ganneffprotect (
   time    INTEGER NOT NULL,
   pattern VARCHAR(255) NOT NULL,
   reason  VARCHAR(255) NOT NULL
-)
-
-CREATE UNIQUE INDEX ganneffserv_channel_idx ON ganneffserv (irc_lower(channel));
+);
+CREATE UNIQUE INDEX ganneffservprotect_pattern_idx ON ganneffservprotect (irc_lower(pattern));

--- a/sql/ganneffserv-pgsql.sql
+++ b/sql/ganneffserv-pgsql.sql
@@ -8,4 +8,14 @@ CREATE TABLE ganneffserv (
   kills   INTEGER NOT NULL DEFAULT 0,
   monitor_only BOOLEAN NOT NULL DEFAULT 'False'
 );
+
+DROP TABLE IF EXISTS ganneffprotect CASCADE;
+CREATE TABLE ganneffprotect (
+  id      SERIAL PRIMARY KEY,
+  setter  INTEGER REFERENCES account(id) ON DELETE SET NULL,
+  time    INTEGER NOT NULL,
+  pattern VARCHAR(255) NOT NULL,
+  reason  VARCHAR(255) NOT NULL
+)
+
 CREATE UNIQUE INDEX ganneffserv_channel_idx ON ganneffserv (irc_lower(channel));


### PR DESCRIPTION
Without this, anyone using irccloud (or a similar service) can get all other users k:lined
by tripping on a trap (J).

Goal: they should be treated like a tor user (getting themselves killed).

---
Background: I'm an irccloud user, and today someone managed to trip on a `J` trap which got my connection to oftc k:lined.

@dwfreed said that we could add some sort of pattern/mask support to enable users like me not to suffer when other irccloud users do harmless stupid things.

Implementation:
1. This adds an extra sql table (I'm not an expert in any of this -- SQL, Ruby, Services, IRCD, so obviously my code should be carefully reviewed)
2. This adds two commands `PROTECT` and `UNPROTECT` -- I'm not attached to the command names (or anything else really). Both take irc masks or regular expressions (the former being converted into the latter).
3. Some extra state variables are added, and when a `akill` is called, after checking if the user is on tor, the code tries to check to see if the host would match a protected pattern -- if so, the kill is downgraded to the user just as for tor users.